### PR TITLE
significantly reduce cpu usage

### DIFF
--- a/BrightXDR/MetalView.swift
+++ b/BrightXDR/MetalView.swift
@@ -43,11 +43,7 @@ class MetalView: MTKView, MTKViewDelegate {
         // Allow the view to display its contents outside of the framebuffer and bind the delegate to the coordinator
         self.framebufferOnly = false
         // Update FPS (matter only on space switching or on/off HDR brightness mode)
-        if #available(macOS 12.0, *) {
-            self.preferredFramesPerSecond = NSScreen.main?.maximumFramesPerSecond ?? 120
-        } else {
-            self.preferredFramesPerSecond = 120
-        }
+        self.preferredFramesPerSecond = 3
         // Enable EDR
         self.colorPixelFormat = .rgba16Float
         self.colorspace = colorSpace


### PR DESCRIPTION
from ~20% to ~2%

In my case I am experiencing white flahshes with the "change space" animation but it happens even with 120 fps. So this is overall better for me. With `self.preferredFramesPerSecond = 1` i experience regular flashes every second. With `2` it's ok. I picked `3` to be somewhat safer :) but I am not sure why it would flash at all.

I am using an M1 Max Macbook Pro